### PR TITLE
Update speedtest.class.php

### DIFF
--- a/core/class/speedtest.class.php
+++ b/core/class/speedtest.class.php
@@ -95,9 +95,9 @@ class speedtest extends eqLogic {
 		$cmd = 'sudo speedtest-cli' . $server . ' --share';
 		$cmd = exec($cmd,$results);
 		if (count($results) == 1) {
-			$changed = $eq->checkAndUpdateCmd('status', 0) || $changed;
+			$changed = $eq->checkAndUpdateCmd('status', 0);
 		} else {
-			$changed = $eq->checkAndUpdateCmd('status', 1) || $changed;
+			$changed = $eq->checkAndUpdateCmd('status', 1);
 		}
 		
 		foreach ($results as $result) {


### PR DESCRIPTION
Je propose ces changements afin de corriger les erreurs présentes dans le log cron_execution:
PHP Notice:  Undefined variable: changed in /var/www/html/plugins/speedtest/core/class/speedtest.class.php on line 100

la variable changed n'est pas encore affectée et ne peut donc être utilisée dans l'expression.